### PR TITLE
Update AGENTS docs to use ajv

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ Copilot and collaborators should treat this file as the project's *north star* �
 
 ### 🧱 Folder Structure Convention
 
-```
+```text
 src/
 ├── controllers/    # Request handling only (no business logic)
 ├── services/       # Encapsulates business logic and external APIs
@@ -47,7 +47,7 @@ src/
 
 ### ✅ Input Validation
 
-- Use `zod` or `joi` in `middleware/validate.js` to define schemas for:
+- Use `ajv` in `middleware/validate.js` to define schemas for:
   - Route params
   - Query params
   - Body inputs
@@ -86,7 +86,7 @@ The frontend is built with vanilla JS/CSS/HTML.
 
 ## 💬 Commit Message Convention (Optional)
 
-```
+```text
 feat: add GitHub PR diff service
 fix: sanitize Azure zone name input
 refactor: split GitLab controller to service
@@ -108,7 +108,7 @@ These rules should always be followed and respected by Copilot:
 
 ### Node.js Best Practices
 
-- Use `zod`, `ajv`, or `joi` for schema validation
+ - Use `ajv` for schema validation
 - Sanitize input with `validator`
 - Never use `eval`, `new Function`, or dynamic `require()`
 - Use `helmet` in Express to add security headers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Project Overview
+
+- **Purpose:** Web dashboard and API for automating DevOps tasks across GitHub, GitLab, Azure, Namecheap, and Wave.
+- **Stack:** Node.js (>=22) with Express 5. Frontend served from `public/` using vanilla HTML, CSS, and JS.
+
+## Repository Structure
+
+```text
+src/
+  controllers/    # Request handlers only
+  services/       # Business logic (future)
+  utils/          # Pure helpers (future)
+  middleware/     # Validation/auth (future)
+  server.js       # Express entry point
+public/           # Static frontend assets
+```
+
+## Key Guidelines
+
+- Follow `.github/copilot-instructions.md` for architecture:
+  - Keep controllers thin and delegate to services.
+  - Use middleware with `ajv` to validate all params, queries, and body data.
+  - Sanitize input and add security headers with `helmet`.
+  - No business logic in controllers; services should be pure functions when possible.
+- Run `npm run lint` (or `lint:fix`) before committing.
+- Never commit secrets. Use environment variables only for local development (`.env.example` shows required keys).
+
+## Preferred Libraries
+
+For future development and expansion, these packages are recommended:
+
+### Dev Dependencies
+
+```text
+@eslint/js, @eslint/json, @eslint/markdown,
+@jest/globals, eslint, eslint-plugin-import,
+globals, jest, jest-junit, nodemon,
+supertest, tailwindcss,
+@babel/eslint-parser, @babel/preset-react,
+@types/react, @types/react-dom,
+@vitejs/plugin-react, eslint-plugin-react,
+eslint-plugin-react-hooks, eslint-plugin-react-refresh,
+stylelint, stylelint-config-standard,
+stylelint-config-tailwindcss, vite
+```
+
+### Runtime Dependencies
+
+```text
+ajv, ajv-formats, amqplib, dotenv,
+ejs, express, helmet, nodemailer,
+path, validator, winston, winston-transport,
+@tailwindcss/typography, @tailwindcss/vite,
+react, react-dom, react-icons, react-router-dom
+```
+
+Use these libraries wherever they help extend the project while still aligning with the core architecture.


### PR DESCRIPTION
## Summary
- update validation library guidance in AGENTS.md
- switch copilot instructions to reference `ajv`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688256e106848327bddc3323ca22ef22